### PR TITLE
Fix bug can not change sqlite path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ check_database_connection() {
       prog="${prog} -h ${DB_HOST} -p ${DB_PORT} -U ${DB_USERNAME} -d ${DB_DATABASE} -t 1"
       ;;
     sqlite)
-      prog="touch /var/www/html/database/database.sqlite"
+      prog="touch ${DB_DATABASE:-/var/www/html/database/database.sqlite}"
   esac
   timeout=60
   while ! ${prog} >/dev/null 2>&1
@@ -100,7 +100,6 @@ initialize_system() {
   fi
 
   if [[ "${DB_DRIVER}" = "sqlite" ]]; then
-    DB_DATABASE=""
     DB_HOST=""
     DB_PORT=""
     DB_USERNAME=""


### PR DESCRIPTION
Some people would like to use sqlite for simplier deployment and would like to move it to a persistent docker volume. Currently, it's hard coded in entrypoint.sh and does not respect the env $DB_DATABASE value, so any config of both $DB_DATABASE and $DB_DRIVER=sqlite will cause error.